### PR TITLE
Lists update

### DIFF
--- a/wizard/lists.playground.md
+++ b/wizard/lists.playground.md
@@ -40,14 +40,17 @@ To put a blockquote within a list item, the blockquote’s > delimiters need to 
 
     > This is a blockquote
     > inside a list item.
+
 To put a code block within a list item, the code block needs to be indented twice — 8 spaces or two tabs:
 
 *   A list item with a code block:
 
         <code goes here>
+
 It’s worth noting that it’s possible to trigger an ordered list by accident, by writing something like this:
 
 1986. What a great season.
+
 In other words, a number-period-space sequence at the beginning of a line. To avoid this, you can backslash-escape the period:
 
 1986\. What a great season.

--- a/wizard/lists.playground.md
+++ b/wizard/lists.playground.md
@@ -17,12 +17,14 @@
 - And if you have sub lists, put two extra spaces before the sub list items.
   - Like this
   - And this
+- You can also mix...
+  1. Ordered lists
+  1. And unordered lists
+
+It’s important to note that the actual numbers you use to mark an ordered list have no effect on the HTML output Markdown produces.
 
 
 ---
-
-
-It’s important to note that the actual numbers you use to mark the list have no effect on the HTML output Markdown produces.
 
 
 If you put blank lines between items, you’ll get `<p>` tags for the list item text. You can create multi-paragraph list items by indenting the paragraphs by 4 spaces or 1 tab:

--- a/wizard/lists.playground.md
+++ b/wizard/lists.playground.md
@@ -49,10 +49,26 @@ To put a code block within a list item, the code block needs to be indented twic
 
         <code goes here>
 
+
+---
+
+
 It’s worth noting that it’s possible to trigger an ordered list by accident, by writing something like this:
+
+```markdown
+1986. What a great season.
+```
+
+Result:
 
 1986. What a great season.
 
-In other words, a number-period-space sequence at the beginning of a line. To avoid this, you can backslash-escape the period:
+In other words, a number-period-space sequence at the beginning of a line will always result in an ordered list. To avoid this, you can backslash-escape the period:
+
+```markdown
+1986\. What a great season.
+```
+
+Result:
 
 1986\. What a great season.


### PR DESCRIPTION
- Resolved issue with missing line-breaks in several places that resulted in trailing text being included in list content.
- Added demonstration of mixed lists.
- Added clarification of accidental ordered lists.
